### PR TITLE
cleanup utm links

### DIFF
--- a/getting-started/hybrid-agent-tutorial.ipynb
+++ b/getting-started/hybrid-agent-tutorial.ipynb
@@ -4,8 +4,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "![](https://europe-west1-atp-views-tracker.cloudfunctions.net/working-analytics?notebook=tutorials--agent-with-tavily-web-access--hybrid-agent-tutorial)\n",
-    "\n",
     "## 3. Combine Internal Data with Web Data 🌐🤝📊\n",
     "\n",
     "Welcome to tutorial 3!\n",
@@ -36,7 +34,7 @@
     "\n",
     "Follow these steps to set up:\n",
     "\n",
-    "1. **Sign up** for Tavily at [app.tavily.com](https://app.tavily.com/home/?utm_source=github&utm_medium=referral&utm_campaign=nir_diamant) to get your API key.\n",
+    "1. **Sign up** for Tavily at [app.tavily.com](https://app.tavily.com/home/) to get your API key.\n",
     "\n",
     "   *Refer to the screenshots linked below for step-by-step guidance:*\n",
     "\n",

--- a/getting-started/search-extract-crawl.ipynb
+++ b/getting-started/search-extract-crawl.ipynb
@@ -4,8 +4,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "![](https://europe-west1-atp-views-tracker.cloudfunctions.net/working-analytics?notebook=tutorials--agent-with-tavily-web-access--search-extract-crawl)\n",
-    "\n",
     "# 1. Search, Extract, and Crawl the Web 🌐\n",
     "\n",
     "Welcome! In this tutorial, you'll gain hands-on experience with the core capabilities of the Tavily API—searching the web with semantic understanding, extracting content from live web pages, and crawling entire websites. \n",
@@ -30,7 +28,7 @@
     "\n",
     "Follow these steps to set up:\n",
     "\n",
-    "1. **Sign up** for Tavily at [app.tavily.com](https://app.tavily.com/home/?utm_source=github&utm_medium=referral&utm_campaign=nir_diamant) to get your API key.\n",
+    "1. **Sign up** for Tavily at [app.tavily.com](https://app.tavily.com/home) to get your API key.\n",
     "\n",
     "   *Refer to the screenshots linked below for step-by-step guidance:*\n",
     "\n",
@@ -153,7 +151,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Let's experiment with different API parameter configurations to see Tavily in action. Try everything from broad topics to specific questions! You can adjust parameters such as the number of results, time range, and domain filters to tailor your search. For more information, read the search [API reference](https://docs.tavily.com/documentation/api-reference/endpoint/search?utm_source=github&utm_medium=referral&utm_campaign=nir_diamant) and [best practices guide](https://docs.tavily.com/documentation/best-practices/best-practices-search?utm_source=github&utm_medium=referral&utm_campaign=nir_diamant). Let's apply a time range filter, domain filter, and use the `news` search topic.\n"
+    "Let's experiment with different API parameter configurations to see Tavily in action. Try everything from broad topics to specific questions! You can adjust parameters such as the number of results, time range, and domain filters to tailor your search. For more information, read the search [API reference](https://docs.tavily.com/documentation/api-reference/endpoint/search) and [best practices guide](https://docs.tavily.com/documentation/best-practices/best-practices-search). Let's apply a time range filter, domain filter, and use the `news` search topic.\n"
    ]
   },
   {
@@ -199,7 +197,7 @@
    "source": [
     "## Extract 📄 \n",
     "\n",
-    "Next, we'll use the Tavily extract endpoint to retrieve the complete content (i.e., `raw_content`) of each page using the URLs from our previous search results. Instead of just using the short content snippets from the search, this allows us to access the full text of each page. For efficiency, the extract endpoint can process up to 20 URLs at once in a single call. For more information, read the extract [API reference](https://docs.tavily.com/documentation/api-reference/endpoint/extract?utm_source=github&utm_medium=referral&utm_campaign=nir_diamant) and [best practices guide](https://docs.tavily.com/documentation/best-practices/best-practices-extract?utm_source=github&utm_medium=referral&utm_campaign=nir_diamant). \n"
+    "Next, we'll use the Tavily extract endpoint to retrieve the complete content (i.e., `raw_content`) of each page using the URLs from our previous search results. Instead of just using the short content snippets from the search, this allows us to access the full text of each page. For efficiency, the extract endpoint can process up to 20 URLs at once in a single call. For more information, read the extract [API reference](https://docs.tavily.com/documentation/api-reference/endpoint/extract) and [best practices guide](https://docs.tavily.com/documentation/best-practices/best-practices-extract). \n"
    ]
   },
   {
@@ -284,7 +282,7 @@
    "source": [
     "## Crawl 🕸️ \n",
     "\n",
-    "Now let’s use Tavily to crawl a webpage and extract all its links. Web crawling is the process of automatically navigating through websites by following hyperlinks to discover numerous web pages and URLs (think of it like falling down a Wikipedia rabbit hole 🐇—clicking from page to page, diving deeper into interconnected topics). For autonomous web agents, this capability is essential for accessing deep web data which might be difficult to retrieve via search. For more information, read the crawl [API reference](https://docs.tavily.com/documentation/api-reference/endpoint/crawl?utm_source=github&utm_medium=referral&utm_campaign=nir_diamant) and [best practices guide](https://docs.tavily.com/documentation/best-practices/best-practices-crawl?utm_source=github&utm_medium=referral&utm_campaign=nir_diamant).\n"
+    "Now let’s use Tavily to crawl a webpage and extract all its links. Web crawling is the process of automatically navigating through websites by following hyperlinks to discover numerous web pages and URLs (think of it like falling down a Wikipedia rabbit hole 🐇—clicking from page to page, diving deeper into interconnected topics). For autonomous web agents, this capability is essential for accessing deep web data which might be difficult to retrieve via search. For more information, read the crawl [API reference](https://docs.tavily.com/documentation/api-reference/endpoint/crawl) and [best practices guide](https://docs.tavily.com/documentation/best-practices/best-practices-crawl).\n"
    ]
   },
   {
@@ -430,7 +428,7 @@
     "- Crawl and map websites to gather links and information\n",
     "- Guide crawls with natural language instructions for targeted data extraction\n",
     " \n",
-    "These foundational skills enable your agents to access and utilize up-to-date web information, making them more powerful and context-aware. Feel free to experiment with the Tavily API in the [playground](https://app.tavily.com/playground?utm_source=github&utm_medium=referral&utm_campaign=nir_diamant) and read the [best practices guide](https://docs.tavily.com/documentation/best-practices/best-practices-search?utm_source=github&utm_medium=referral&utm_campaign=nir_diamant) to optimize for your use case.\n",
+    "These foundational skills enable your agents to access and utilize up-to-date web information, making them more powerful and context-aware. Feel free to experiment with the Tavily API in the [playground](https://app.tavily.com/playground) and read the [best practices guide](https://docs.tavily.com/documentation/best-practices/best-practices-search) to optimize for your use case.\n",
     " \n",
     "**Ready to take the next step?**  \n",
     "In **Tutorial #2: Building a Web Agent** that can search, extract, and crawl autonomously, you'll combine these capabilities to build a fully autonomous web agent. This agent will be able to reason, decide when to search, crawl, or extract, and integrate web data into its workflow—all powered by Tavily.\n",

--- a/getting-started/web-agent-tutorial.ipynb
+++ b/getting-started/web-agent-tutorial.ipynb
@@ -4,8 +4,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "![](https://europe-west1-atp-views-tracker.cloudfunctions.net/working-analytics?notebook=tutorials--agent-with-tavily-web-access--web-agent-tutorial)\n",
-    "\n",
     "# 2. Build a Web Research Agent 🧙 \n",
     "\n",
     "Welcome to tutorial 2!\n",
@@ -42,7 +40,7 @@
     "\n",
     "Follow these steps to set up:\n",
     "\n",
-    "1. **Sign up** for Tavily at [app.tavily.com](https://app.tavily.com/home/?utm_source=github&utm_medium=referral&utm_campaign=nir_diamant) to get your API key.\n",
+    "1. **Sign up** for Tavily at [app.tavily.com](https://app.tavily.com/home) to get your API key.\n",
     "\n",
     "   *Refer to the screenshots linked below for step-by-step guidance:*\n",
     "\n",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Removes analytics tracking pixels and cleans Tavily/docs links by stripping UTM parameters across getting-started notebooks.
> 
> - **Docs (getting-started notebooks)**:
>   - **Remove tracking pixels** from:
>     - `getting-started/search-extract-crawl.ipynb`
>     - `getting-started/web-agent-tutorial.ipynb`
>     - `getting-started/hybrid-agent-tutorial.ipynb`
>   - **Clean URLs (strip UTM params / standardize links)** in markdown content:
>     - Update Tavily signup links to `https://app.tavily.com/home` (or `/home/`).
>     - Update docs references to canonical URLs (search/extract/crawl API refs, best practices, playground).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fe6682de060710ab7e030b63426046e84e6919ee. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->