### PR TITLE
updated with get_research method

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ The Tavily Cookbook provides code and guides designed to help developers build w
 
 ## Prerequisites
 
-**Sign up** for Tavily at [app.tavily.com](https://app.tavily.com/home/?utm_source=github&utm_medium=referral&utm_campaign=nir_diamant) to get your API key.
+**Sign up** for Tavily at [app.tavily.com](https://app.tavily.com/home/) to get your API key.
 
 While the code examples are primarily written in Python, the concepts can be adapted to any programming language that supports interaction with the Tavily API.
 

--- a/research/polling.ipynb
+++ b/research/polling.ipynb
@@ -7,7 +7,7 @@
    "source": [
     "# Tavily research endpoint with polling\n",
     "\n",
-    "Research calls are handled by an agent that may take several minutes to ccomplete. To accommodate this, we've provided an endpoint that allows you to poll for the research results as they become available."
+    "Research calls are handled by an agent that may take several minutes to complete. To accommodate this, we've provided an endpoint that allows you to poll for the research results as they become available."
    ]
   },
   {
@@ -17,12 +17,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%pip install -qU tavily-python pydantic"
+    "%pip install -qU tavily-python"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 10,
    "id": "3b0f9c65",
    "metadata": {},
    "outputs": [],
@@ -30,6 +30,7 @@
     "import getpass\n",
     "import os\n",
     "from tavily import TavilyClient\n",
+    "import time\n",
     "\n",
     "from IPython.display import display, Markdown\n",
     "\n",
@@ -52,7 +53,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 11,
    "id": "d7479f7d",
    "metadata": {},
    "outputs": [],
@@ -70,7 +71,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 12,
    "id": "eb2a7451",
    "metadata": {},
    "outputs": [],
@@ -95,7 +96,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 13,
    "id": "075f2b15",
    "metadata": {},
    "outputs": [],
@@ -118,7 +119,17 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "print(\"Status:\", response[\"status\"])\n",
+    "# Poll until the research is completed\n",
+    "while response[\"status\"] not in [\"completed\", \"failed\"]:\n",
+    "    print(f\"Status: {response['status']}... polling again in 10 seconds\")\n",
+    "    time.sleep(10)\n",
+    "    response = tavily_client.get_research(request_id)\n",
+    "\n",
+    "# Check if the research completed successfully\n",
+    "if response[\"status\"] == \"failed\":\n",
+    "    raise RuntimeError(f\"Research failed: {response.get('error', 'Unknown error')}\")\n",
+    "\n",
+    "print(\"Research Complete!\")\n",
     "report = Markdown(response[\"content\"])\n",
     "display(report)"
    ]

--- a/research/polling.ipynb
+++ b/research/polling.ipynb
@@ -7,7 +7,7 @@
    "source": [
     "# Tavily research endpoint with polling\n",
     "\n",
-    "A research call invokes a longer running agent which can take minutes to do in depth research. Because of this we have created an endpoint where you can poll the response.\n"
+    "Research calls are handled by an agent that may take several minutes to ccomplete. To accommodate this, we've provided an endpoint that allows you to poll for the research results as they become available."
    ]
   },
   {
@@ -30,8 +30,7 @@
     "import getpass\n",
     "import os\n",
     "from tavily import TavilyClient\n",
-    "import time\n",
-    "import httpx\n",
+    "\n",
     "from IPython.display import display, Markdown\n",
     "\n",
     "if not os.environ.get(\"TAVILY_API_KEY\"):\n",
@@ -48,27 +47,7 @@
    "source": [
     "## Make a Polling Request\n",
     "\n",
-    "- Let's begin by sending a request to start the research and then poll for the result.\n",
-    "- When you send a research request endpoint, you'll receive a response containing a \"request_id\" field.\n",
-    "- This request_id is used to track the progress of your research request.\n"
-   ]
-  },
-  {
-   "cell_type": "raw",
-   "id": "bc5a2be2",
-   "metadata": {
-    "vscode": {
-     "languageId": "raw"
-    }
-   },
-   "source": [
-    "{\n",
-    "    \"request_id\": \"...\",\n",
-    "    \"status\": \"pending\",\n",
-    "    \"input\": \"...\",\n",
-    "    \"created_at\": \"2025-11-17T21:52:30.834714+00:00\",\n",
-    "    \"model\": \"...\"\n",
-    "}"
+    "Let's begin by sending a request to the research API"
    ]
   },
   {
@@ -78,7 +57,24 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "result = tavily_client.research(input=\"What are the latest developments in artificial intelligence?\", model=\"mini\") # model = \"mini\" | \"pro\" | \"auto\"\n",
+    "result = tavily_client.research(input=\"What are the latest developments in artificial intelligence?\", model=\"mini\") # model = \"mini\" | \"pro\" | \"auto\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b42f2dd0",
+   "metadata": {},
+   "source": [
+    "After submitting a research request to the endpoint, you'll receive a response that includes a \"request_id\".\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "eb2a7451",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "request_id = result[\"request_id\"]"
    ]
   },
@@ -87,55 +83,14 @@
    "id": "b0f55201",
    "metadata": {},
    "source": [
-    "To check the progress or result of your research request, send a GET request to: https://api.tavily.com/research/{request_id}\n",
+    "After submitting your research request, you can track its progress using the `get_research` method along with the received request_id.\n",
     "\n",
-    "The \"status\" field in the response will indicate the current state of your request and can be one of:\n",
+    "The response will include a \"status\" field that reflects the current stage of your request. The possible status values are:\n",
     "\n",
-    "- \"pending\"\n",
-    "- \"in progress\"\n",
-    "- \"completed\"\n",
-    "- \"failed\"\n",
-    "\n",
-    "When the status is completed you can access the report from the \"content\" field.\n"
-   ]
-  },
-  {
-   "cell_type": "raw",
-   "id": "4985089c",
-   "metadata": {
-    "vscode": {
-     "languageId": "raw"
-    }
-   },
-   "source": [
-    "{\n",
-    "  \"request_id\": \"xxx\",\n",
-    "  \"created_at\": \"2025-01-15T10:30:00Z\",\n",
-    "  \"status\": \"completed\",\n",
-    "  \"content\": \".....\",\n",
-    "  \"sources\": [\n",
-    "    {\n",
-    "      \"title\": \"Latest AI Developments\",\n",
-    "      \"url\": \"https://example.com/ai-news\"\n",
-    "    },\n",
-    "    {\n",
-    "      \"title\": \"AI Research Breakthroughs\",\n",
-    "      \"url\": \"https://example.com/ai-research\"\n",
-    "    }\n",
-    "  ],\n",
-    "  \"response_time\": 1.23\n",
-    "}"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "6403c14a",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "url = \"https://api.tavily.com/research/\"\n",
-    "headers = {\"Authorization\": f\"Bearer {TAVILY_API_KEY}\"}"
+    "- \"pending\": Your request is waiting to be processed.\n",
+    "- \"in progress\": Your request is currently being processed.\n",
+    "- \"completed\": The research has finished and results are available.\n",
+    "- \"failed\": There was an issue processing your request.\n"
    ]
   },
   {
@@ -145,29 +100,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "research_report = \"\"\n",
-    "sources = []\n",
-    "\n",
-    "# Poll every 10 seconds\n",
-    "while True:\n",
-    "    response = httpx.get(url + request_id, headers=headers)\n",
-    "    response_json = response.json()\n",
-    "\n",
-    "    status = response_json[\"status\"]\n",
-    "    if status == \"completed\":\n",
-    "        research_report = response_json[\"content\"]\n",
-    "        sources = response_json[\"sources\"]\n",
-    "        break\n",
-    "\n",
-    "    if status == \"failed\":\n",
-    "        raise RuntimeError(f\"Research failed: {response_json['error']}\")\n",
-    "\n",
-    "    print(f\"Status: {status}... polling again in 10 seconds\")\n",
-    "    time.sleep(10)\n",
-    "\n",
-    "print(\"Research Complete!\")\n",
-    "report = Markdown(research_report)\n",
-    "display(report)"
+    "response = tavily_client.get_research(request_id)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0eea748a",
+   "metadata": {},
+   "source": [
+    "When the status is `completed` you can access the report from the \"content\" field."
    ]
   },
   {
@@ -177,13 +118,25 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sources"
+    "print(\"Status:\", response[\"status\"])\n",
+    "report = Markdown(response[\"content\"])\n",
+    "display(report)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4e7a67bf",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "response['sources']"
    ]
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "venv",
    "language": "python",
    "name": "python3"
   },
@@ -197,7 +150,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.7"
+   "version": "3.13.2"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Research polling example modernized**
> 
> - Rewrites `research/polling.ipynb` to use `TavilyClient.get_research` for status checks instead of manual `httpx` GET requests
> - Removes unnecessary dependencies (`pydantic`, `httpx`) and simplifies install to `tavily-python`
> - Adds concise polling loop using the client; clarifies response `status` values and access to `content` and `sources`
> - Minor README update: trims tracking params from `app.tavily.com` signup link
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8c7e888fe45c5603b0277e824f3c28154dd1e903. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->