### PR TITLE
remote mcp, langchain, skills, updated research cookbooks

### DIFF
--- a/integrations/langchain/langchain.ipynb
+++ b/integrations/langchain/langchain.ipynb
@@ -1,0 +1,586 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# LangChain + Tavily Integration Cookbook"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The `langchain-tavily` package provides native LangChain tools that integrate seamlessly with LangChain's agent frameworks and LangGraph workflows.\n",
+    "\n",
+    "By the end of this cookbook, you'll know how to:\n",
+    "- Use TavilySearch for real-time web search\n",
+    "- Use TavilyExtract to get full page content from URLs\n",
+    "- Use TavilyMap to discover site structure and internal links\n",
+    "- Use TavilyCrawl for deep website crawling\n",
+    "- Use TavilyResearch for comprehensive research tasks\n",
+    "- Build a LangGraph agent with all Tavily tools\n",
+    "\n",
+    "---"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Getting Started\n",
+    "\n",
+    "1. **Sign up** for Tavily at [app.tavily.com](https://app.tavily.com/home/) to get your API key.\n",
+    "2. **Copy your API key** from your Tavily account dashboard.\n",
+    "3. **Run the cells below** to set up your environment."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%pip install -qU langchain-tavily langchain-openai langgraph python-dotenv"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import getpass\n",
+    "from dotenv import load_dotenv\n",
+    "\n",
+    "load_dotenv()\n",
+    "\n",
+    "if not os.environ.get(\"TAVILY_API_KEY\"):\n",
+    "    os.environ[\"TAVILY_API_KEY\"] = getpass.getpass(\"TAVILY_API_KEY:\\n\")\n",
+    "\n",
+    "if not os.environ.get(\"OPENAI_API_KEY\"):\n",
+    "    os.environ[\"OPENAI_API_KEY\"] = getpass.getpass(\"OPENAI_API_KEY:\\n\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "\n",
+    "## 1. TavilySearch - Web Search Tool\n",
+    "\n",
+    "TavilySearch executes search queries using Tavily's Search API. It returns relevant web results with titles, URLs, content snippets, and relevance scores.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from langchain_tavily import TavilySearch\n",
+    "\n",
+    "# Initialize the search tool with default settings\n",
+    "search = TavilySearch(\n",
+    "    max_results=5,\n",
+    "    topic=\"general\",\n",
+    "    search_depth=\"basic\",\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Basic search invocation\n",
+    "result = search.invoke({\"query\": \"What are the latest developments in AI agents?\"})\n",
+    "\n",
+    "print(f\"Query: {result['query']}\")\n",
+    "print(f\"Response time: {result['response_time']}s\")\n",
+    "print(f\"Number of results: {len(result['results'])}\")\n",
+    "print(\"\\n\" + \"=\"*60 + \"\\n\")\n",
+    "\n",
+    "for i, r in enumerate(result[\"results\"], 1):\n",
+    "    print(f\"Result {i}:\")\n",
+    "    print(f\"  Title: {r['title']}\")\n",
+    "    print(f\"  URL: {r['url']}\")\n",
+    "    print(f\"  Score: {r['score']:.4f}\")\n",
+    "    print(f\"  Content: {r['content'][:200]}...\")\n",
+    "    print()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### News Search with Time Range"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Search for recent news\n",
+    "news_search = TavilySearch(\n",
+    "    max_results=5,\n",
+    "    topic=\"news\",\n",
+    "    time_range=\"week\",\n",
+    ")\n",
+    "\n",
+    "news_result = news_search.invoke({\"query\": \"OpenAI announcements\"})\n",
+    "\n",
+    "for i, r in enumerate(news_result[\"results\"], 1):\n",
+    "    print(f\"{i}. {r['title']}\")\n",
+    "    print(f\"   {r['url']}\\n\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Domain-Filtered Search"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Search only specific domains\n",
+    "domain_search = TavilySearch(\n",
+    "    max_results=5,\n",
+    "    include_domains=[\"arxiv.org\", \"openai.com\", \"anthropic.com\"],\n",
+    ")\n",
+    "\n",
+    "domain_result = domain_search.invoke({\"query\": \"large language model research\"})\n",
+    "\n",
+    "for i, r in enumerate(domain_result[\"results\"], 1):\n",
+    "    print(f\"{i}. {r['title']}\")\n",
+    "    print(f\"   {r['url']}\\n\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "\n",
+    "## 2. TavilyExtract - Content Extraction Tool\n",
+    "\n",
+    "TavilyExtract retrieves the full content from one or more URLs. It's useful when you need the complete text of a webpage rather than just search snippets."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from langchain_tavily import TavilyExtract\n",
+    "\n",
+    "extract = TavilyExtract(\n",
+    "    extract_depth=\"basic\",\n",
+    "    include_images=False,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Extract content from a single URL\n",
+    "extract_result = extract.invoke({\n",
+    "    \"urls\": [\"https://en.wikipedia.org/wiki/Artificial_intelligence\"]\n",
+    "})\n",
+    "\n",
+    "print(f\"Response time: {extract_result['response_time']}s\")\n",
+    "print(f\"Number of results: {len(extract_result['results'])}\")\n",
+    "print(f\"Failed results: {len(extract_result['failed_results'])}\")\n",
+    "print(\"\\n\" + \"=\"*60 + \"\\n\")\n",
+    "\n",
+    "for r in extract_result[\"results\"]:\n",
+    "    print(f\"URL: {r['url']}\")\n",
+    "    print(f\"Content length: {len(r['raw_content'])} characters\")\n",
+    "    print(f\"Preview: {r['raw_content'][:500]}...\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Extract from multiple URLs at once (up to 20)\n",
+    "multi_extract = extract.invoke({\n",
+    "    \"urls\": [\n",
+    "        \"https://docs.tavily.com\",\n",
+    "        \"https://python.langchain.com/docs/introduction/\"\n",
+    "    ]\n",
+    "})\n",
+    "\n",
+    "for r in multi_extract[\"results\"]:\n",
+    "    print(f\"URL: {r['url']}\")\n",
+    "    print(f\"Content length: {len(r['raw_content'])} characters\\n\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "\n",
+    "## 3. TavilyMap - Site Structure Discovery\n",
+    "\n",
+    "TavilyMap discovers all internal links from a base URL without extracting content. It's useful for understanding site structure before crawling."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from langchain_tavily import TavilyMap\n",
+    "\n",
+    "map_tool = TavilyMap()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Map a documentation site\n",
+    "map_result = map_tool.invoke({\n",
+    "    \"url\": \"www.tavily.com\",\n",
+    "    \"instructions\": \"Find all API documentation and integration pages\"\n",
+    "})\n",
+    "\n",
+    "print(f\"Base URL: {map_result['base_url']}\")\n",
+    "print(f\"Response time: {map_result['response_time']}s\")\n",
+    "print(f\"URLs discovered: {len(map_result['results'])}\")\n",
+    "print(\"\\nDiscovered URLs:\")\n",
+    "\n",
+    "for url in map_result[\"results\"][:15]:\n",
+    "    print(f\"  - {url}\")\n",
+    "\n",
+    "if len(map_result[\"results\"]) > 15:\n",
+    "    print(f\"  ... and {len(map_result['results']) - 15} more\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "\n",
+    "## 4. TavilyCrawl - Deep Website Crawling\n",
+    "\n",
+    "TavilyCrawl combines mapping and extraction to crawl entire websites and retrieve content from multiple pages. Use natural language instructions to guide what content to focus on."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from langchain_tavily import TavilyCrawl\n",
+    "\n",
+    "crawl = TavilyCrawl()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Crawl documentation for specific content\n",
+    "crawl_result = crawl.invoke({\n",
+    "    \"url\": \"www.tavily.com\",\n",
+    "    \"instructions\": \"Extract API reference and code examples\",\n",
+    "})\n",
+    "\n",
+    "print(f\"Base URL: {crawl_result['base_url']}\")\n",
+    "print(f\"Response time: {crawl_result['response_time']}s\")\n",
+    "print(f\"Pages crawled: {len(crawl_result['results'])}\")\n",
+    "print(\"\\n\" + \"=\"*60 + \"\\n\")\n",
+    "\n",
+    "for i, page in enumerate(crawl_result[\"results\"][:3], 1):\n",
+    "    print(f\"Page {i}: {page['url']}\")\n",
+    "    print(f\"Content preview: {page['raw_content'][:300]}...\")\n",
+    "    print()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "\n",
+    "## 5. TavilyResearch - Comprehensive Research\n",
+    "\n",
+    "TavilyResearch creates comprehensive research reports on complex topics. It automatically searches, synthesizes, and cites sources.\n",
+    "\n",
+    "### Key Parameters\n",
+    "\n",
+    "| Parameter | Type | Default | Description |\n",
+    "|-----------|------|---------|-------------|\n",
+    "| `model` | str | \"auto\" | \"mini\", \"pro\", or \"auto\" |\n",
+    "| `citation_format` | str | \"numbered\" | \"numbered\", \"mla\", \"apa\", \"chicago\" |\n",
+    "| `stream` | bool | False | Stream results as generated |"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from langchain_tavily import TavilyResearch, TavilyGetResearch\n",
+    "import time\n",
+    "\n",
+    "research = TavilyResearch(\n",
+    "    model=\"mini\",\n",
+    "    citation_format=\"numbered\",\n",
+    ")\n",
+    "\n",
+    "get_research = TavilyGetResearch()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Start a research task\n",
+    "research_task = research.invoke({\n",
+    "    \"input\": \"What are the key differences between LangChain and LlamaIndex for building RAG applications?\"\n",
+    "})\n",
+    "\n",
+    "print(f\"Research task created:\")\n",
+    "print(f\"  Request ID: {research_task['request_id']}\")\n",
+    "print(f\"  Status: {research_task['status']}\")\n",
+    "print(f\"  Model: {research_task['model']}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Poll for results\n",
+    "request_id = research_task[\"request_id\"]\n",
+    "\n",
+    "while True:\n",
+    "    result = get_research.invoke({\"request_id\": request_id})\n",
+    "    status = result[\"status\"]\n",
+    "    print(f\"Status: {status}\")\n",
+    "    \n",
+    "    if status == \"completed\":\n",
+    "        break\n",
+    "    elif status == \"failed\":\n",
+    "        print(\"Research failed\")\n",
+    "        break\n",
+    "    \n",
+    "    time.sleep(2)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from IPython.display import display, Markdown\n",
+    "\n",
+    "if result[\"status\"] == \"completed\":\n",
+    "    display(Markdown(result[\"content\"]))\n",
+    "    \n",
+    "    print(\"\\n\" + \"=\"*60)\n",
+    "    print(\"Sources:\")\n",
+    "    for i, source in enumerate(result.get(\"sources\", []), 1):\n",
+    "        print(f\"  [{i}] {source['title']}\")\n",
+    "        print(f\"      {source['url']}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "\n",
+    "## 6. Building a LangGraph Agent with Tavily Tools\n",
+    "\n",
+    "Now let's combine all the Tavily tools into a powerful research agent using LangGraph."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 40,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from langchain_openai import ChatOpenAI\n",
+    "from langchain.agents import create_agent\n",
+    "from langchain_core.prompts import ChatPromptTemplate\n",
+    "import datetime\n",
+    "\n",
+    "# Initialize the LLM\n",
+    "llm = ChatOpenAI(model=\"gpt-5-mini-2025-08-07\", temperature=0)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 41,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Set up Tavily tools for the agent\n",
+    "search_tool = TavilySearch(\n",
+    "    max_results=10,\n",
+    "    search_depth=\"advanced\",\n",
+    "    include_raw_content=True,\n",
+    ")\n",
+    "\n",
+    "extract_tool = TavilyExtract(\n",
+    "    extract_depth=\"advanced\",\n",
+    ")\n",
+    "\n",
+    "crawl_tool = TavilyCrawl()\n",
+    "\n",
+    "tools = [search_tool, extract_tool, crawl_tool]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 46,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Create system prompt\n",
+    "today = datetime.datetime.now().strftime(\"%B %d, %Y\")\n",
+    "\n",
+    "system_prompt = f\"\"\"You are an expert research assistant with access to powerful web tools.\n",
+    "\n",
+    "Today's date: {today}\n",
+    "\n",
+    "Your available tools:\n",
+    "\n",
+    "1. **TavilySearch**: Search the web for information\n",
+    "   - Use for finding recent news, articles, and general information\n",
+    "   - Returns ranked results with titles, URLs, and content snippets\n",
+    "\n",
+    "2. **TavilyExtract**: Extract full content from URLs\n",
+    "   - Use when you need the complete text of a specific webpage\n",
+    "   - Can process up to 20 URLs at once\n",
+    "\n",
+    "3. **TavilyCrawl**: Crawl websites for deep content\n",
+    "   - Use for exploring documentation sites or gathering comprehensive information\n",
+    "   - Provide clear instructions about what content to focus on\n",
+    "\n",
+    "Research guidelines:\n",
+    "- Start with a search to identify relevant sources\n",
+    "- Use extract to get full content from promising URLs\n",
+    "- Use crawl for documentation sites or when you need comprehensive coverage\n",
+    "- Always cite your sources with URLs\n",
+    "- Synthesize information from multiple sources\n",
+    "- Be thorough but concise in your responses\n",
+    "\"\"\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 47,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Create the agent\n",
+    "agent = create_agent(\n",
+    "    model=llm,\n",
+    "    tools=tools,\n",
+    "    system_prompt=system_prompt,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 48,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Test the agent\n",
+    "response = agent.invoke({\n",
+    "    \"messages\": [{\"role\": \"user\", \"content\": \"What are the main features of LangGraph and how does it compare to other agent frameworks?\"}]\n",
+    "})"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Display the final response\n",
+    "final_message = response[\"messages\"][-1]\n",
+    "display(Markdown(final_message.content))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# View tool execution flow\n",
+    "print(\"Tool Execution Flow\")\n",
+    "print(\"=\" * 50)\n",
+    "\n",
+    "for msg in response[\"messages\"]:\n",
+    "    if hasattr(msg, \"tool_calls\") and msg.tool_calls:\n",
+    "        for tc in msg.tool_calls:\n",
+    "            print(f\"Tool: {tc['name']}\")\n",
+    "            args = tc.get(\"args\", {})\n",
+    "            for key, value in args.items():\n",
+    "                if isinstance(value, str) and len(value) > 80:\n",
+    "                    value = value[:77] + \"...\"\n",
+    "                print(f\"  {key}: {value}\")\n",
+    "            print()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "venv",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/mcp/remote-mcp.ipynb
+++ b/mcp/remote-mcp.ipynb
@@ -1,0 +1,148 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "intro",
+   "metadata": {},
+   "source": [
+    "# Tavily Remote MCP Server\n",
+    "\n",
+    "Tavily provides a **remote MCP server** that gives AI agents real-time web search and content extraction capabilities — no local installation required.\n",
+    "\n",
+    "This notebook demonstrates how to use Tavily's remote MCP server with OpenAI's Client.\n",
+    "\n",
+    "\n",
+    "## Setup"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "install",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%pip install -qU openai"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "api-keys",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import getpass\n",
+    "\n",
+    "if not os.environ.get(\"TAVILY_API_KEY\"):\n",
+    "    os.environ[\"TAVILY_API_KEY\"] = getpass.getpass(\"TAVILY_API_KEY:\\n\")\n",
+    "\n",
+    "if not os.environ.get(\"OPENAI_API_KEY\"):\n",
+    "    os.environ[\"OPENAI_API_KEY\"] = getpass.getpass(\"OPENAI_API_KEY:\\n\")\n",
+    "\n",
+    "TAVILY_API_KEY = os.environ[\"TAVILY_API_KEY\"]\n",
+    "OPENAI_API_KEY = os.environ[\"OPENAI_API_KEY\"]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "config-header",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "\n",
+    "## Configure the MCP Server\n",
+    "\n",
+    "The remote MCP server URL includes your Tavily API key as a query parameter:\n",
+    "\n",
+    "```\n",
+    "https://mcp.tavily.com/mcp/?tavilyApiKey=<your-api-key>\n",
+    "```\n",
+    "\n",
+    "This provides access to two tools:\n",
+    "- **tavily-search**: Real-time web search\n",
+    "- **tavily-extract**: Content extraction from URLs"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "config",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tools = [\n",
+    "    {\n",
+    "        \"type\": \"mcp\",\n",
+    "        \"server_url\": f\"https://mcp.tavily.com/mcp/?tavilyApiKey={TAVILY_API_KEY}\",\n",
+    "        \"server_label\": \"tavily\",\n",
+    "        \"require_approval\": \"never\",\n",
+    "    }\n",
+    "]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "usage-header",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "\n",
+    "## Use with OpenAI\n",
+    "\n",
+    "Pass the MCP tool configuration to OpenAI's `responses.create` method. The model will automatically use Tavily's search tool when needed."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "usage",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from openai import OpenAI\n",
+    "\n",
+    "client = OpenAI(api_key=OPENAI_API_KEY)\n",
+    "\n",
+    "response = client.responses.create(\n",
+    "    model=\"gpt-4.1\",\n",
+    "    tools=tools,\n",
+    "    input=\"What happened in NYC this week?\",\n",
+    ")\n",
+    "\n",
+    "print(response.output_text)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "resources",
+   "metadata": {},
+   "source": [
+    "\n",
+    "For more details on configuration options, Claude Desktop/Cursor setup, and advanced usage, see the [Tavily MCP Documentation](https://docs.tavily.com/documentation/mcp)."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "venv",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/research/clarification.ipynb
+++ b/research/clarification.ipynb
@@ -1,228 +1,226 @@
 {
-  "cells": [
-    {
-      "cell_type": "markdown",
-      "id": "03d30c67",
-      "metadata": {},
-      "source": [
-        "## Prompt Clarification for Research\n",
-        "\n",
-        "Deep research models work best with detailed, well-structured prompts. When users provide vague or underspecified queries, we can guide them toward providing more detail by gathering clarifying information before invoking the research service.\n",
-        "\n",
-        "This notebook demonstrates how to use an LLM to interactively refine a research query through clarifying questions, ensuring the final prompt is specific, unambiguous, and aligned with what the user actually wants to learn.\n",
-        "\n",
-        "**How it works**\n",
-        "\n",
-        "1. **Initial input**: User provides a research query (potentially vague or incomplete)\n",
-        "2. **Clarification loop**: An LLM evaluates the query and asks targeted follow-up questions to gather missing details\n",
-        "3. **Iterative refinement**: The user responds, and the loop continues until the LLM determines it has enough context (or a max iteration limit is reached)\n",
-        "4. **Research**: The refined, detailed prompt is passed to Tavily's research API\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "44331cdb",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "%pip install -qU tavily-python pydantic\n",
-        "%pip install -qU \"langchain[openai]\""
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "3b0f9c65",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "import getpass\n",
-        "import os\n",
-        "from tavily import TavilyClient\n",
-        "\n",
-        "if not os.environ.get(\"TAVILY_API_KEY\"):\n",
-        "    os.environ[\"TAVILY_API_KEY\"] = getpass.getpass(\"TAVILY_API_KEY:\\n\")\n",
-        "\n",
-        "if not os.environ.get(\"OPENAI_API_KEY\"):\n",
-        "    os.environ[\"OPENAI_API_KEY\"] = getpass.getpass(\"OPENAI_API_KEY:\\n\")\n",
-        "\n",
-        "TAVILY_API_KEY = os.getenv(\"TAVILY_API_KEY\")\n",
-        "tavily_client = TavilyClient(api_key=TAVILY_API_KEY)\n",
-        "\n",
-        "headers = {\"Authorization\": f\"Bearer {TAVILY_API_KEY}\"}\n",
-        "url = \"https://api.tavily.com/research/\""
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "6a2b19e3",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "from langchain.chat_models import init_chat_model\n",
-        "from pydantic import BaseModel, Field\n",
-        "import time\n",
-        "import httpx\n",
-        "from IPython.display import display, Markdown\n",
-        "\n",
-        "model = init_chat_model(\"gpt-5-mini\", model_provider=\"openai\")"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "a1b2c3d4",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "class ClarificationResponse(BaseModel):\n",
-        "    \"\"\"Structured response for query clarification.\"\"\"\n",
-        "    needs_clarification: bool = Field(description=\"True if more info needed, False if ready to research\")\n",
-        "    message: str = Field(description=\"Either follow-up questions OR the refined research query\")\n",
-        "\n",
-        "PROMPT = \"\"\"You are a research assistant refining a research query through conversation.\n",
-        "\n",
-        "Original topic: {query}\n",
-        "\n",
-        "Conversation:\n",
-        "{conversation}\n",
-        "\n",
-        "If you need more details, set needs_clarification=True and ask 2-3 questions about:\n",
-        "- Specific subtopics, time frame, depth needed, relevant contexts, or source types\n",
-        "\n",
-        "If you have enough context, set needs_clarification=False and provide a detailed refined query.\n",
-        "\"\"\"\n",
-        "\n",
-        "FORCE_FINAL_PROMPT = \"\"\"You are a research assistant refining a research query through conversation.\n",
-        "\n",
-        "Original topic: {query}\n",
-        "\n",
-        "Conversation:\n",
-        "{conversation}\n",
-        "\n",
-        "Based on the conversation so far, produce a detailed refined research query.\n",
-        "Set needs_clarification=False and provide the best possible refined query using the context gathered.\n",
-        "\"\"\"\n",
-        "\n",
-        "def clarify(query: str, conversation: list, force_final: bool = False) -> ClarificationResponse:\n",
-        "    conv_text = \"\\n\".join(f\"{m['role'].title()}: {m['content']}\" for m in conversation) or \"(none)\"\n",
-        "    prompt = FORCE_FINAL_PROMPT if force_final else PROMPT\n",
-        "    return model.with_structured_output(ClarificationResponse).invoke(\n",
-        "        prompt.format(query=query, conversation=conv_text)\n",
-        "    )"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "e5f6g7h8",
-      "metadata": {},
-      "source": [
-        "## Interactive Query Refinement\n",
-        "\n",
-        "> Note: This example uses `input()` for interactive prompts. If you're running in an environment that doesn't support stdin for notebooks (for example, some IDEs or hosted runners), you can replace the `input()` calls with hard-coded strings for `initial_query` and the follow-up replies.\n",
-        "\n",
-        "> This cell is primarily meant as a simple example of how to implement an interactive clarification loop—feel free to adapt the flow and UX for your own application.\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "93146532",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "max_iterations = 3\n",
-        "\n",
-        "# Get initial query from user\n",
-        "initial_query = input(\"What would you like to research?\\n> \")\n",
-        "conversation = []\n",
-        "\n",
-        "# Refinement loop\n",
-        "for i in range(max_iterations):\n",
-        "    response = clarify(initial_query, conversation)\n",
-        "    \n",
-        "    if not response.needs_clarification:\n",
-        "        refined_query = response.message\n",
-        "        print(f\"\\n✅ Refined query:\\n{refined_query}\")\n",
-        "        break\n",
-        "    \n",
-        "    print(f\"\\n🤖 Assistant:\\n{response.message}\")\n",
-        "    conversation.append({\"role\": \"assistant\", \"content\": response.message})\n",
-        "    \n",
-        "    user_input = input(\"\\n> \")\n",
-        "    print(\"Your input: \", user_input)\n",
-        "    conversation.append({\"role\": \"user\", \"content\": user_input})\n",
-        "else:\n",
-        "    # Max iterations reached - force final query\n",
-        "    response = clarify(initial_query, conversation, force_final=True)\n",
-        "    refined_query = response.message\n",
-        "    print(f\"\\n✅ Refined query:\\n{refined_query}\")"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "g7h8i9j0",
-      "metadata": {},
-      "source": [
-        "## Execute Research\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "075f2b15",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "result = tavily_client.research(input=refined_query, model=\"mini\")\n",
-        "request_id = result[\"request_id\"]\n",
-        "\n",
-        "# Poll until complete\n",
-        "while True:\n",
-        "    resp = httpx.get(f\"{url}{request_id}\", headers=headers).json()\n",
-        "    if resp[\"status\"] == \"completed\":\n",
-        "        break\n",
-        "    if resp[\"status\"] == \"failed\":\n",
-        "        raise RuntimeError(f\"Research failed: {resp['error']}\")\n",
-        "    print(f\"Status: {resp['status']}... polling in 10s\")\n",
-        "    time.sleep(10)\n",
-        "\n",
-        "print(\"\\n✅ Research Complete!\\n\")\n",
-        "display(Markdown(resp[\"content\"]))"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "3a070abc",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "resp.get(\"sources\", [])"
-      ]
-    }
-  ],
-  "metadata": {
-    "kernelspec": {
-      "display_name": "Python 3",
-      "language": "python",
-      "name": "python3"
-    },
-    "language_info": {
-      "codemirror_mode": {
-        "name": "ipython",
-        "version": 3
-      },
-      "file_extension": ".py",
-      "mimetype": "text/x-python",
-      "name": "python",
-      "nbconvert_exporter": "python",
-      "pygments_lexer": "ipython3",
-      "version": "3.12.7"
-    }
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "03d30c67",
+   "metadata": {},
+   "source": [
+    "## Prompt Clarification for Research\n",
+    "\n",
+    "Deep research models work best with detailed, well-structured prompts. When users provide vague or underspecified queries, we can guide them toward providing more detail by gathering clarifying information before invoking the research service.\n",
+    "\n",
+    "This notebook demonstrates how to use an LLM to interactively refine a research query through clarifying questions, ensuring the final prompt is specific, unambiguous, and aligned with what the user actually wants to learn.\n",
+    "\n",
+    "**How it works**\n",
+    "\n",
+    "1. **Initial input**: User provides a research query (potentially vague or incomplete)\n",
+    "2. **Clarification loop**: An LLM evaluates the query and asks targeted follow-up questions to gather missing details\n",
+    "3. **Iterative refinement**: The user responds, and the loop continues until the LLM determines it has enough context (or a max iteration limit is reached)\n",
+    "4. **Research**: The refined, detailed prompt is passed to Tavily's research API\n"
+   ]
   },
-  "nbformat": 4,
-  "nbformat_minor": 5
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "44331cdb",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%pip install -qU tavily-python pydantic\n",
+    "%pip install -qU \"langchain[openai]\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "3b0f9c65",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import getpass\n",
+    "import os\n",
+    "from tavily import TavilyClient\n",
+    "\n",
+    "if not os.environ.get(\"TAVILY_API_KEY\"):\n",
+    "    os.environ[\"TAVILY_API_KEY\"] = getpass.getpass(\"TAVILY_API_KEY:\\n\")\n",
+    "\n",
+    "if not os.environ.get(\"OPENAI_API_KEY\"):\n",
+    "    os.environ[\"OPENAI_API_KEY\"] = getpass.getpass(\"OPENAI_API_KEY:\\n\")\n",
+    "\n",
+    "TAVILY_API_KEY = os.getenv(\"TAVILY_API_KEY\")\n",
+    "tavily_client = TavilyClient(api_key=TAVILY_API_KEY)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "6a2b19e3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from langchain.chat_models import init_chat_model\n",
+    "from pydantic import BaseModel, Field\n",
+    "import time\n",
+    "from IPython.display import display, Markdown\n",
+    "\n",
+    "model = init_chat_model(\"gpt-4o-mini\", model_provider=\"openai\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "a1b2c3d4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "class ClarificationResponse(BaseModel):\n",
+    "    \"\"\"Structured response for query clarification.\"\"\"\n",
+    "    needs_clarification: bool = Field(description=\"True if more info needed, False if ready to research\")\n",
+    "    message: str = Field(description=\"Either follow-up questions OR the refined research query\")\n",
+    "\n",
+    "PROMPT = \"\"\"You are a research assistant refining a research query through conversation.\n",
+    "\n",
+    "Original topic: {query}\n",
+    "\n",
+    "Conversation:\n",
+    "{conversation}\n",
+    "\n",
+    "If you need more details, set needs_clarification=True and ask 2-3 questions about:\n",
+    "- Specific subtopics, time frame, depth needed, relevant contexts, or source types\n",
+    "\n",
+    "If you have enough context, set needs_clarification=False and provide a detailed refined query.\n",
+    "\"\"\"\n",
+    "\n",
+    "FORCE_FINAL_PROMPT = \"\"\"You are a research assistant refining a research query through conversation.\n",
+    "\n",
+    "Original topic: {query}\n",
+    "\n",
+    "Conversation:\n",
+    "{conversation}\n",
+    "\n",
+    "Based on the conversation so far, produce a detailed refined research query.\n",
+    "Set needs_clarification=False and provide the best possible refined query using the context gathered.\n",
+    "\"\"\"\n",
+    "\n",
+    "def clarify(query: str, conversation: list, force_final: bool = False) -> ClarificationResponse:\n",
+    "    conv_text = \"\\n\".join(f\"{m['role'].title()}: {m['content']}\" for m in conversation) or \"(none)\"\n",
+    "    prompt = FORCE_FINAL_PROMPT if force_final else PROMPT\n",
+    "    return model.with_structured_output(ClarificationResponse).invoke(\n",
+    "        prompt.format(query=query, conversation=conv_text)\n",
+    "    )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e5f6g7h8",
+   "metadata": {},
+   "source": [
+    "## Interactive Query Refinement\n",
+    "\n",
+    "> Note: This example uses `input()` for interactive prompts. If you're running in an environment that doesn't support stdin for notebooks (for example, some IDEs or hosted runners), you can replace the `input()` calls with hard-coded strings for `initial_query` and the follow-up replies.\n",
+    "\n",
+    "> This cell is primarily meant as a simple example of how to implement an interactive clarification loop—feel free to adapt the flow and UX for your own application.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "93146532",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "max_iterations = 3\n",
+    "\n",
+    "# Get initial query from user\n",
+    "initial_query = input(\"What would you like to research?\\n> \")\n",
+    "conversation = []\n",
+    "\n",
+    "# Refinement loop\n",
+    "for i in range(max_iterations):\n",
+    "    response = clarify(initial_query, conversation)\n",
+    "    \n",
+    "    if not response.needs_clarification:\n",
+    "        refined_query = response.message\n",
+    "        print(f\"\\n✅ Refined query:\\n{refined_query}\")\n",
+    "        break\n",
+    "    \n",
+    "    print(f\"\\n🤖 Assistant:\\n{response.message}\")\n",
+    "    conversation.append({\"role\": \"assistant\", \"content\": response.message})\n",
+    "    \n",
+    "    user_input = input(\"\\n> \")\n",
+    "    print(\"Your input: \", user_input)\n",
+    "    conversation.append({\"role\": \"user\", \"content\": user_input})\n",
+    "else:\n",
+    "    # Max iterations reached - force final query\n",
+    "    response = clarify(initial_query, conversation, force_final=True)\n",
+    "    refined_query = response.message\n",
+    "    print(f\"\\n✅ Refined query:\\n{refined_query}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "g7h8i9j0",
+   "metadata": {},
+   "source": [
+    "## Execute Research\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "075f2b15",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "result = tavily_client.research(input=refined_query, model=\"mini\")\n",
+    "request_id = result[\"request_id\"]\n",
+    "\n",
+    "response = tavily_client.get_research(request_id)\n",
+    "\n",
+    "# Poll until the research is completed\n",
+    "while response[\"status\"] not in [\"completed\", \"failed\"]:\n",
+    "    print(f\"Status: {response['status']}... polling again in 10 seconds\")\n",
+    "    time.sleep(10)\n",
+    "    response = tavily_client.get_research(request_id)\n",
+    "\n",
+    "# Check if the research completed successfully\n",
+    "if response[\"status\"] == \"failed\":\n",
+    "    raise RuntimeError(f\"Research failed: {response.get('error', 'Unknown error')}\")\n",
+    "\n",
+    "print(\"\\n✅ Research Complete!\\n\")\n",
+    "display(Markdown(response[\"content\"]))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3a070abc",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "response.get(\"sources\", [])"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
 }

--- a/research/structured_output.ipynb
+++ b/research/structured_output.ipynb
@@ -66,14 +66,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "id": "cf8eee62",
    "metadata": {},
    "outputs": [],
    "source": [
     "import getpass\n",
     "import os\n",
-    "import httpx\n",
     "import time\n",
     "from IPython.display import display, JSON\n",
     "from tavily import TavilyClient\n",
@@ -86,8 +85,16 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "af25156d",
+   "metadata": {},
+   "source": [
+    "## Define the Structured Output Schema"
+   ]
+  },
+  {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "id": "9c24c059",
    "metadata": {},
    "outputs": [],
@@ -178,52 +185,27 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "bc35c477",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "headers = {\"Authorization\": f\"Bearer {TAVILY_API_KEY}\"}\n",
-    "url = \"https://api.tavily.com/research/\""
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
    "id": "8cd807f6",
    "metadata": {},
    "outputs": [],
    "source": [
-    "payload = {\n",
-    "    \"input\": input,\n",
-    "    \"model\": model,\n",
-    "    \"output_schema\": output_schema,\n",
-    "}\n",
-    "\n",
     "result = tavily_client.research(input=input, model=model, output_schema=output_schema, stream=False)\n",
     "request_id = result[\"request_id\"]\n",
     "\n",
-    "research_report_structured_output = \"\"\n",
-    "sources = []\n",
+    "response = tavily_client.get_research(request_id)\n",
     "\n",
-    "# Poll every 10 seconds\n",
-    "while True:\n",
-    "    response = httpx.get(url + request_id, headers=headers)\n",
-    "    response_json = response.json()\n",
-    "\n",
-    "    status = response_json[\"status\"]\n",
-    "    if status == \"completed\":\n",
-    "        research_report_structured_output = response_json[\"content\"]\n",
-    "        sources = response_json[\"sources\"]\n",
-    "        break\n",
-    "\n",
-    "    if status == \"failed\":\n",
-    "        raise RuntimeError(f\"Research failed for {response_json['request_id']}\")\n",
-    "\n",
-    "    print(f\"Status: {status}... polling again in 10 seconds\")\n",
+    "# Poll until the research is completed\n",
+    "while response[\"status\"] not in [\"completed\", \"failed\"]:\n",
+    "    print(f\"Status: {response['status']}... polling again in 10 seconds\")\n",
     "    time.sleep(10)\n",
+    "    response = tavily_client.get_research(request_id)\n",
+    "\n",
+    "# Check if the research completed successfully\n",
+    "if response[\"status\"] == \"failed\":\n",
+    "    raise RuntimeError(f\"Research failed: {response.get('error', 'Unknown error')}\")\n",
     "\n",
     "print(\"Research Complete!\")\n",
-    "JSON(research_report_structured_output)"
+    "JSON(response[\"content\"])"
    ]
   },
   {
@@ -233,13 +215,13 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sources"
+    "response[\"sources\"]"
    ]
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "venv",
    "language": "python",
    "name": "python3"
   },
@@ -253,7 +235,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.7"
+   "version": "3.13.2"
   }
  },
  "nbformat": 4,

--- a/skills/tavily-api/SKILL.md
+++ b/skills/tavily-api/SKILL.md
@@ -1,0 +1,77 @@
+---
+name: tavily-api
+description: Implement web search, url content extraction, website crawling, and deep research with the tavily API. Use when building agentic workflows, rag systems, or autonomous agents that require real-time context from the web.
+---
+
+Tavily is a specialized search API designed specifically for LLMs, enabling developers to build AI applications that can access real-time, accurate web data. Let's use the Python SDK to build with tavily.
+
+# Tavily Python SDK
+
+## Installation
+
+```bash
+pip install tavily-python
+```
+
+## Client Initialization
+
+```python
+from tavily import TavilyClient
+
+client = TavilyClient(api_key="tvly-YOUR_API_KEY")
+
+# Or use environment variable TAVILY_API_KEY
+client = TavilyClient()
+```
+
+**Async client:**
+
+The async client enables parallel query execution, ideal for agentic workflows that need to gather information quickly before passing it to a model for analysis.
+
+```python
+from tavily import AsyncTavilyClient
+
+async_client = AsyncTavilyClient(api_key="tvly-YOUR_API_KEY")
+```
+
+## Available Endpoints
+
+| Endpoint | Purpose | Use Case |
+|--------|---------|----------|
+| `search()` | Web search | real time data retrieval from the web |
+| `extract()` | Scrape content from URLs | Page content extraction |
+| `crawl() and map()` | Traverse website structures and simultaneously scrape pages | Documentation, site-wide extraction |
+| `research` | Out of the box research agent | ready-to-use iterative research |
+
+
+
+
+## Choosing the Right Method
+
+**If you are building a custom agent or agentic workflow:**
+
+| Need | Method |
+|------|--------|
+| Web search results | `search()` |
+| Content from specific URLs | `extract()` |
+| Content from an entire site | `crawl()` |
+| URL discovery from a site | `map()` |
+
+These methods give you full control but require additional work: data processing, LLM integration, and workflow orchestration.
+
+**If you want an out-of-the-box solution:**
+
+| Need | Method |
+|------|--------|
+| End-to-end research with AI synthesis and built-in context engineering | `research()` |
+
+The research endpoint provides faster time-to-value with AI-synthesized insights, but offers less flexibility than building custom workflows.
+
+## Detailed Guides
+
+For detailed usage instructions, parameters, patterns, and best practices:
+
+- **[references/search.md](references/search.md)** — Query optimization, filtering, async patterns, post-filtering strategies (regex + LLM verification)
+- **[references/extract.md](references/extract.md)** — One-step vs two-step extraction, advanced mode, research pipelines
+- **[references/crawl.md](references/crawl.md)** — Crawl vs Map, depth/breadth control, path patterns, performance optimization
+- **[references/research.md](references/research.md)** — Usage, Streaming, structured output, polling

--- a/skills/tavily-api/references/crawl.md
+++ b/skills/tavily-api/references/crawl.md
@@ -1,0 +1,170 @@
+# Crawl & Map API Reference
+
+## Table of Contents
+
+- [Crawl vs Map](#crawl-vs-map)
+- [Basic Usage](#basic-usage)
+  - [Crawl](#basic-crawl)
+  - [Map](#basic-map)
+- [Key Parameters](#key-parameters)
+- [Path Filtering](#path-filtering)
+- [Map then Extract Pattern](#map-then-extract-pattern)
+- [Performance Optimization](#performance-optimization)
+- [Response Fields](#response-fields)
+
+---
+
+## Crawl vs Map
+
+| Use Case | API | Why |
+|----------|-----|-----|
+| Full content extraction | **Crawl** | Returns page content |
+| Site structure discovery | **Map** | Returns URLs only, faster, less tokens for LLM |
+| URL collection | **Map** | No content overhead |
+| RAG integration | **Crawl** | Need actual content |
+
+---
+
+## Basic Usage
+
+### Basic Crawl
+
+```python
+from tavily import TavilyClient
+
+client = TavilyClient()
+
+response = client.crawl(
+    url="https://docs.example.com"
+)
+
+for page in response["results"]:
+    print(f"{page['url']}: {len(page['raw_content'])} chars")
+```
+
+### Basic Map
+
+```python
+response = client.map(
+    url="https://docs.example.com"
+)
+
+for url in response["urls"]:
+    print(url)
+```
+
+---
+
+## Key Parameters
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `url` | string | Required | The root URL to begin the crawl |
+| `max_depth` | integer | 1 | How deep to follow links (1-5). Start with 1-2, increase gradually |
+| `max_breadth` | integer | 20 | Links followed per level. 50-100 for focused crawls |
+| `limit` | integer | 50 | Total pages to crawl before stopping |
+| `chunks_per_source` | integer | 3 | Content chunks per page (1-5, max 500 chars each). Reduces tokens for LLM context |
+| `extract_depth` | enum | `"basic"` | `"basic"` (1 credit/5 URLs) or `"advanced"` (2 credits/5 URLs) |
+| `format` | enum | `"markdown"` | Output format: `"markdown"` or `"text"` |
+| `select_paths` | array | null | Regex patterns to include specific URL paths |
+| `exclude_paths` | array | null | Regex patterns to exclude specific URL paths |
+| `select_domains` | array | null | Regex patterns to include specific domains |
+| `exclude_domains` | array | null | Regex patterns to exclude specific domains |
+| `allow_external` | boolean | true | Include or exclude external domain links |
+| `include_images` | boolean | false | Include images in results |
+| `include_favicon` | boolean | false | Include favicon URL for each result |
+| `instructions` | string | null | Natural language guidance for crawler (2 credits/10 pages) |
+| `timeout` | float | 150 | Max wait time in seconds (10-150) |
+
+**Notes:**
+
+- **Token efficiency**: Use `chunks_per_source` and `instructions` to optimize token usage for LLM agents. `chunks_per_source` limits content per page to only the most relevant snippets, while `instructions` guides the crawler to focus on specific content types, reducing irrelevant data in your context window.
+
+---
+
+## Path Filtering
+
+Focus crawling on specific sections using regex patterns:
+
+```python
+# Only crawl documentation and API reference
+response = client.crawl(
+    url="https://docs.example.com",
+    max_depth=2,
+    select_paths=["/docs/.*", "/api/.*", "/reference/.*"],
+    exclude_paths=["/blog/.*", "/changelog/.*"]
+)
+```
+
+**Domain control:**
+
+```python
+response = client.crawl(
+    url="https://example.com",
+    select_domains=["example.com", "docs.example.com"],
+    exclude_domains=["ads.example.com"]
+)
+```
+
+
+---
+
+## Map then Extract Pattern
+
+Discover structure first, then extract strategically:
+
+```python
+# Step 1: Map to discover structure
+map_result = client.map(
+    url="https://docs.example.com",
+    instructions="find all api docs and guides"
+    max_depth=2
+)
+
+# Step 2: Filter discovered URLs
+api_docs = [url for url in map_result["urls"] if "/api/" in url]
+guides = [url for url in map_result["urls"] if "/guides/" in url]
+print(f"Found {len(api_docs)} API docs, {len(guides)} guides")
+
+# Step 3: Extract content from filtered URLs
+target_urls = api_docs + guides
+response = client.extract(
+    urls=target_urls[:20],  # Max 20 URLs per extract call
+    extract_depth="advanced"
+)
+
+for item in response["results"]:
+    print(f"{item['url']}: {len(item['raw_content'])} chars")
+```
+
+---
+
+## Performance Optimization
+
+### Depth Impact
+
+Each depth level increases crawl time exponentially:
+
+| Depth | Typical Pages | Time |
+|-------|---------------|------|
+| 1 | 10-50 | Seconds |
+| 2 | 50-500 | Minutes |
+| 3 | 500-5000 | Many minutes |
+
+## Response Fields
+
+### Crawl Response
+
+| Field | Description |
+|-------|-------------|
+| `results` | List of crawled pages |
+| `results[].url` | Page URL |
+| `results[].raw_content` | Extracted content |
+
+### Map Response
+
+| Field | Description |
+|-------|-------------|
+| `urls` | List of discovered URLs |
+
+For more details, please read the [full API reference](https://docs.tavily.com/documentation/api-reference/endpoint/crawl)

--- a/skills/tavily-api/references/extract.md
+++ b/skills/tavily-api/references/extract.md
@@ -1,0 +1,122 @@
+# Extract API Reference
+
+## Table of Contents
+
+- [Extraction Strategies](#extraction-strategies)
+  - [One-Step Extraction](#one-step-extraction)
+  - [Two-Step Extraction](#two-step-extraction-recommended)
+- [Key Parameters](#key-parameters)
+- [Notes](#notes)
+
+
+---
+
+## Extraction Strategies
+
+### One-Step Extraction
+
+Enable `include_raw_content=True` during search to get content immediately. Simple but may extract irrelevant content.
+
+```python
+from tavily import TavilyClient
+
+client = TavilyClient()
+
+response = client.search(
+    query="Python async best practices",
+    include_raw_content=True,
+    max_results=10
+)
+
+for result in response["results"]:
+    print(f"Content length: {len(result.get('raw_content', ''))}")
+```
+
+### Two-Step Extraction (Recommended)
+
+Search first, filter by relevance, then extract from selected URLs. More control and accuracy.
+Can extract up to 20 URLs in one extract call.
+
+```python
+# Step 1: Search
+search_results = client.search(
+    query="Python async best practices",
+    max_results=10
+)
+
+# Step 2: Filter by relevance score
+relevant_urls = [
+    r["url"] for r in search_results["results"]
+    if r["score"] > 0.5
+]
+
+# Step 3: Extract from filtered URLs
+extracted = client.extract(urls=relevant_urls)
+
+for item in extracted["results"]:
+    print(f"URL: {item['url']}")
+    print(f"Content: {item['raw_content'][:500]}...")
+```
+
+---
+
+## Key Parameters
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `urls` | string/array | Required | Single URL or list of URLs to extract (max 20) |
+| `extract_depth` | enum | `"basic"` | `"basic"` or `"advanced"` (for complex/JS-rendered pages) |
+| `query` | string | null | Reranks extracted chunks based on relevance to this query |
+| `chunks_per_source` | integer | 3 | Number of content chunks per source (1-5, max 500 chars each) |
+| `format` | enum | `"markdown"` | Output format: `"markdown"` or `"text"` |
+| `include_images` | boolean | false | Include image URLs from extracted pages |
+| `include_favicon` | boolean | false | Include favicon URL for each result |
+| `timeout` | float | varies | Max wait time in seconds (1.0-60.0) |
+
+
+## Notes
+
+- **Token optimization**: Use `query` and `chunks_per_source` to reduce the number of tokens returned. This is ideal for LLM agents and context engineering where you want only the most relevant content.
+
+- **Timeout tuning**: If latency is not a concern, set `timeout` to the maximum (60.0) to increase the chances of a successful scrape on slower or complex pages.
+
+
+- **Advanced Mode** Use `extract_depth="advanced"` for complex pages:
+
+**Best for:**
+- Dynamic content with JavaScript
+- Embedded media and tables
+- Complex page structures
+- When precision is critical
+
+- **Fallback strategy**: If `extract_depth="basic"` fails for a URL, retry with `extract_depth="advanced"` which handles more complex page structures and dynamically rendered content.
+
+---
+
+## Response Fields
+
+**Top-level response:**
+
+| Field | Description |
+|-------|-------------|
+| `results` | Array of successfully extracted content |
+| `failed_results` | Array of URLs that failed extraction |
+| `response_time` | Time in seconds to complete the request |
+
+**Each result object:**
+
+| Field | Description |
+|-------|-------------|
+| `url` | The URL from which content was extracted |
+| `raw_content` | Full extracted content. When `query` is provided, contains top-ranked chunks joined by `[...]` |
+| `images` | Array of image URLs (if `include_images=true`) |
+| `favicon` | Favicon URL (if `include_favicon=true`) |
+
+**Each failed_results object:**
+
+| Field | Description |
+|-------|-------------|
+| `url` | The URL that failed extraction |
+| `error` | Error message describing why extraction failed |
+
+For more details, please read the [full API reference](https://docs.tavily.com/documentation/api-reference/endpoint/extract)

--- a/skills/tavily-api/references/research.md
+++ b/skills/tavily-api/references/research.md
@@ -1,0 +1,155 @@
+# Research API Reference
+
+## Table of Contents
+
+- [Overview](#overview)
+- [Basic Usage](#basic-usage)
+- [Key Parameters](#key-parameters)
+- [Response Fields](#response-fields)
+- [Structured Output](#structured-output)
+- [Best Practices](#best-practices)
+
+---
+
+## Overview
+
+The Research API conducts comprehensive research on any topic with automatic source gathering, analysis, and response generation with citations.
+
+
+---
+
+## Basic Usage
+
+Research tasks are two-step: initiate with `research()`, retrieve with `get_research()`.
+
+```python
+from tavily import TavilyClient
+
+client = TavilyClient()
+
+# Step 1: Start research task
+result = client.research(
+    input="Latest developments in quantum computing and their practical applications",
+)
+request_id = result["request_id"]
+
+response = tavily_client.get_research(request_id)
+
+# Poll until the research is completed
+while response["status"] not in ["completed", "failed"]:
+    print(f"Status: {response['status']}... polling again in 10 seconds")
+    time.sleep(10)
+    response = tavily_client.get_research(request_id)
+
+# Check if the research completed successfully
+if response["status"] == "failed":
+    raise RuntimeError(f"Research failed: {response.get('error', 'Unknown error')}")
+
+report = response["content"]
+
+```
+
+---
+
+## Key Parameters
+
+### research()
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `input` | string | Required | The research topic or question |
+| `model` | enum | `"auto"` | `"mini"` (targeted research), `"pro"` (comprehensive multi-angle analysis), `"auto"` |
+| `stream` | boolean | false | Enable streaming responses |
+| `output_schema` | object | null | JSON Schema defining structured response format |
+| `citation_format` | enum | `"numbered"` | `"numbered"`, `"mla"`, `"apa"`, `"chicago"` |
+
+### get_research()
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `request_id` | string | Task ID from `research()` response |
+
+
+
+---
+
+## Response Fields
+
+### research() Response
+
+| Field | Description |
+|-------|-------------|
+| `request_id` | Unique identifier for tracking the task |
+| `created_at` | Timestamp when the research task was created |
+| `status` | Initial status of the research task |
+| `input` | The research topic or question submitted |
+| `model` | The model used by the research agent |
+
+### get_research() Response
+
+| Field | Description |
+|-------|-------------|
+| `status` | Task status: `"pending"`, `"processing"`, `"completed"`, `"failed"` |
+| `content` | The generated research report (when completed) |
+| `sources` | Array of source citations used in the report |
+| `response_time` | Time in seconds to complete the request |
+
+### Source Object
+
+| Field | Description |
+|-------|-------------|
+| `url` | Source URL |
+| `title` | Source title |
+| `citation` | Formatted citation string |
+
+---
+
+
+## Structured Output
+
+Use `output_schema` to receive research results in a predefined JSON structure:
+
+```python
+schema = {
+    "properties": {
+        "summary": {
+            "type": "string",
+            "description": "Executive summary of findings"
+        },
+        "key_points": {
+            "type": "array",
+            "items": {"type": "string"},
+            "description": "Main takeaways from the research"
+        },
+        "metrics": {
+            "type": "object",
+            "properties": {
+                "market_size": {"type": "string", "description": "Total market size"},
+                "growth_rate": {"type": "number", "description": "Annual growth percentage"}
+            }
+        }
+    },
+    "required": ["summary", "key_points"]
+}
+
+response = client.research(
+    input="Electric vehicle market analysis 2024",
+    output_schema=schema
+)
+```
+
+**Schema requirements:**
+- Every property needs both `type` and `description`
+- Supported types: `object`, `string`, `integer`, `number`, `array`
+- Use `required` arrays to enforce mandatory fields at any nesting level
+
+---
+
+## Best Practices
+
+**Use streaming for UX** — Display progress to users during long research tasks to reduce perceived latency
+**Be specific in topics** — More focused research queries yield more relevant results
+**Use structured output** — Define schemas for consistent, parseable responses in production applications
+
+
+For more examples, see the [Tavily Cookbook](https://github.com/tavily-ai/tavily-cookbook/tree/main/research).

--- a/skills/tavily-api/references/search.md
+++ b/skills/tavily-api/references/search.md
@@ -1,0 +1,338 @@
+# Search API Reference
+
+## Table of Contents
+
+- [Query Optimization](#query-optimization)
+- [Key Parameters](#key-parameters)
+- [Basic Usage](#basic-usage)
+- [Domain Filtering](#domain-filtering)
+- [Image Search](#image-search)
+- [Async Patterns](#async-patterns)
+- [Response Fields](#response-fields)
+- [Post-Filtering Strategies](#post-filtering-strategies)
+  - [Score-Based Filtering](#score-based-filtering)
+  - [Regex Filtering](#regex-filtering)
+  - [LLM Verification](#llm-verification)
+
+---
+
+## Query Optimization
+
+Keep queries concise (just a few words). Break complex searches into smaller, focused sub-queries for better relevance.
+
+## Key Parameters
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `query` | string | Required | The search query to execute |
+| `search_depth` | enum | `"basic"` | `"basic"` (1 snippet/URL) or `"advanced"` (multiple semantic snippets/URL, 2 credits) |
+| `chunks_per_source` | integer | 3 | Max relevant chunks per source (1-3, advanced depth only) |
+| `max_results` | integer | 5 | Maximum results to return (0-20) |
+| `time_range` | enum | null | `"day"`, `"week"`, `"month"`, `"year"` |
+| `start_date` | string | null | Results after this date (YYYY-MM-DD) |
+| `end_date` | string | null | Results before this date (YYYY-MM-DD) |
+| `include_domains` | array | [] | Domains to include (max 300) |
+| `exclude_domains` | array | [] | Domains to exclude (max 150) |
+| `include_answer` | bool/enum | false | `true`/`"basic"` for quick answer, `"advanced"` for detailed |
+| `include_raw_content` | bool/enum | false | `true`/`"markdown"` or `"text"` for full page content |
+| `include_images` | boolean | false | Include image search results |
+| `include_image_descriptions` | boolean | false | Add AI-generated descriptions for images |
+| `include_favicon` | boolean | false | Include favicon URL for each result |
+| `country` | enum | null | Boost results from specific country (general topic only) |
+| `auto_parameters` | boolean | false | Auto-configure parameters based on query intent |
+
+**Notes:**
+
+- **`include_answer`**: Only use this if the user explicitly does not want to bring their own LLM for inference. Most users bring their own model to customize prompts and model selection.
+
+- **`search_depth="advanced"`**: Provides the best quality results at the cost of ~2s additional latency. For use cases that can tolerate added latency, using `search_depth="advanced"` with `chunks_per_source=5` yields significant performance gains in downstream tasks.
+
+
+## Basic Usage
+
+```python
+from tavily import TavilyClient
+
+client = TavilyClient()
+
+response = client.search(
+    query="latest developments in quantum computing",
+    max_results=10,
+    search_depth="advanced",
+    chunks_per_source=5
+)
+
+for result in response["results"]:
+    print(f"{result['title']}: {result['url']}")
+    print(f"Score: {result['score']}")
+```
+
+
+## Domain Filtering
+
+```python
+# Only search trusted sources
+response = client.search(
+    query="machine learning best practices",
+    include_domains=["arxiv.org", "github.com", "pytorch.org"],
+)
+
+# Exclude specific domains
+response = client.search(
+    query="openai product reviews",
+    exclude_domains=["reddit.com", "quora.com"]
+)
+```
+
+
+
+## Async Patterns
+
+Leveraging the async client enables scaled search with higher breadth and reach by running multiple queries in parallel. This is the best practice for agentic systems where you need to gather comprehensive information quickly before passing it to a model for analysis.
+
+```python
+import asyncio
+from tavily import AsyncTavilyClient
+
+# Initialize Tavily client
+tavily_client = AsyncTavilyClient("tvly-YOUR_API_KEY")
+
+async def fetch_and_gather():
+    queries = ["latest AI trends", "future of quantum computing"]
+
+    # Perform search and continue even if one query fails (using return_exceptions=True)
+    try:
+        responses = await asyncio.gather(*(tavily_client.search(q) for q in queries), return_exceptions=True)
+
+        # Handle responses and print
+        for response in responses:
+            if isinstance(response, Exception):
+                print(f"Search query failed: {response}")
+            else:
+                print(response)
+
+    except Exception as e:
+        print(f"Error during search queries: {e}")
+
+# Run the function
+asyncio.run(fetch_and_gather())
+```
+
+
+## Response Fields
+
+**Top-level response:**
+
+| Field | Description |
+|-------|-------------|
+| `query` | The original search query |
+| `answer` | AI-generated answer (if `include_answer` enabled) |
+| `results` | Array of search result objects |
+| `images` | Array of image results (if `include_images=True`) |
+
+**Each result object:**
+
+| Field | Description |
+|-------|-------------|
+| `title` | Page title |
+| `url` | Source URL |
+| `content` | Extracted text snippet(s) |
+| `score` | Semantic relevance score (0-1) |
+| `raw_content` | Full page content (if `include_raw_content` enabled) |
+| `favicon` | Favicon URL (if `include_favicon=True`) |
+
+**Each image object (if `include_images=True`):**
+
+| Field | Description |
+|-------|-------------|
+| `url` | Image URL |
+| `description` | AI-generated description (if `include_image_descriptions=True`) |
+
+---
+
+## Post-Filtering Strategies
+
+Since Tavily provides raw web data, you have full configurability to implement filtering and post-processing to meet your specific requirements.
+
+The `score` field measures query relevance, but doesn't guarantee the result matches specific criteria (e.g., correct person, exact product, specific company). Use post-filtering to validate results against strict requirements.
+
+### Score-Based Filtering
+
+Simple threshold filtering based on relevance score:
+
+```python
+results = response["results"]
+
+# Filter by score threshold
+high_quality = [r for r in results if r["score"] > 0.7]
+
+# Sort by score
+sorted_results = sorted(results, key=lambda x: x["score"], reverse=True)
+
+# Top N above threshold
+top_relevant = sorted(
+    [r for r in results if r["score"] > 0.5],
+    key=lambda x: x["score"],
+    reverse=True
+)[:3]
+```
+
+**Limitation:** Score indicates relevance to query, not accuracy of match to specific criteria.
+
+### Regex Filtering
+
+Fast, deterministic filtering using pattern matching. Use for:
+- URL pattern validation
+- Required keywords/phrases
+- Structural requirements
+
+```python
+import re
+
+def regex_filter(result, criteria: dict) -> dict:
+    """
+    Filter a search result using regex checks.
+
+    Args:
+        result: Search result dict with url, content, title, raw_content
+        criteria: Dict with patterns to match:
+            - url_pattern: Regex for URL validation
+            - required_terms: List of terms that must appear in content
+            - excluded_terms: List of terms that must NOT appear
+
+    Returns:
+        dict with check results and validity
+    """
+    url = result.get("url", "")
+    content = result.get("content", "") or ""
+    title = result.get("title", "") or ""
+    raw_content = result.get("raw_content", "") or ""
+
+    full_text = f"{content} {title} {raw_content}".lower()
+
+    checks = {}
+
+    # URL pattern check
+    if "url_pattern" in criteria:
+        checks["url_valid"] = bool(re.search(criteria["url_pattern"], url.lower()))
+
+    # Required terms check
+    if "required_terms" in criteria:
+        checks["required_found"] = all(
+            re.search(re.escape(term.lower()), full_text)
+            for term in criteria["required_terms"]
+        )
+
+    # Excluded terms check
+    if "excluded_terms" in criteria:
+        checks["excluded_absent"] = not any(
+            re.search(re.escape(term.lower()), full_text)
+            for term in criteria["excluded_terms"]
+        )
+
+    # Valid if all checks pass
+    is_valid = all(checks.values()) if checks else True
+
+    return {"checks": checks, "is_valid": is_valid, "url": url}
+```
+
+**Example: LinkedIn Profile Search**
+
+```python
+criteria = {
+    "url_pattern": r"linkedin\.com/in/",  # Profile URL, not company page
+    "required_terms": ["Jane Smith", "Acme Corp"],
+    "excluded_terms": ["job posting", "careers"]
+}
+
+for result in response["results"]:
+    validation = regex_filter(result, criteria)
+    if validation["is_valid"]:
+        print(f"Valid: {validation['url']}")
+```
+
+**Example: GitHub Repository Search**
+
+```python
+criteria = {
+    "url_pattern": r"github\.com/[\w-]+/[\w-]+$",  # Repo URL, not file
+    "required_terms": ["MIT License"],
+    "excluded_terms": ["archived", "deprecated"]
+}
+```
+
+### LLM Verification
+
+Semantic validation using an LLM. Use for:
+- Synonym/abbreviation matching ("FDE" = "Forward Deployed Engineer")
+- Context-aware validation
+- Confidence scoring with reasoning
+
+```python
+from openai import OpenAI
+import json
+
+def llm_verify(result, target_description: str, validation_criteria: list[str]) -> dict:
+    """
+    Use LLM to verify if a search result matches target criteria.
+
+    Args:
+        result: Search result dict
+        target_description: What you're looking for
+        validation_criteria: List of criteria to check
+
+    Returns:
+        dict with is_match, confidence (high/medium/low), reasoning
+    """
+    content = result.get("content", "") or ""
+    title = result.get("title", "") or ""
+    url = result.get("url", "")
+
+    criteria_text = "\n".join(f"- {c}" for c in validation_criteria)
+
+    prompt = f"""Verify if this search result matches the target.
+
+Target: {target_description}
+
+Validation Criteria:
+{criteria_text}
+
+Search Result:
+URL: {url}
+Title: {title}
+Content: {content}
+
+Does this result match ALL criteria?
+
+Respond with JSON only:
+{{"is_match": true/false, "confidence": "high/medium/low", "reasoning": "brief explanation"}}"""
+
+    client = OpenAI()
+    response = client.chat.completions.create(
+        model="gpt-4o-mini",
+        messages=[{"role": "user", "content": prompt}],
+        response_format={"type": "json_object"}
+    )
+
+    return json.loads(response.choices[0].message.content)
+```
+
+**Example: Profile Verification**
+
+```python
+result = llm_verify(
+    result=search_result,
+    target_description="Jane Smith, Software Engineer at Acme Corp",
+    validation_criteria=[
+        "Name matches Jane Smith",
+        "Currently works at Acme Corp (or recently)",
+        "Role is software engineering related",
+        "Professional customer-facing experience"
+    ]
+)
+
+if result["is_match"] and result["confidence"] in ["high", "medium"]:
+    print(f"Verified: {result['reasoning']}")
+```
+
+For more details, please read the [full API reference](https://docs.tavily.com/documentation/api-reference/endpoint/search)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Adds new examples and docs; simplifies research flows**
> 
> - New `integrations/langchain/langchain.ipynb` cookbook demonstrating `TavilySearch`, `TavilyExtract`, `TavilyMap`, `TavilyCrawl`, `TavilyResearch`, and a LangGraph agent using these tools
> - New `mcp/remote-mcp.ipynb` showing how to use Tavily's remote MCP server with OpenAI `responses.create`
> - New Tavily API skill docs: `skills/tavily-api/SKILL.md` and references for `search`, `extract`, `crawl`, `research`
> - Research notebooks updated for simpler polling: `research/clarification.ipynb` and `research/structured_output.ipynb` now use `TavilyClient.get_research` (remove manual `httpx`/headers), minor kernel/version updates, added schema section in structured output, and model default updated to `gpt-4o-mini`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9669cd7d1676ab773203ccc1dd5035ace453c142. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->