### PR TITLE
Update import examples in READMEs for consistency

### DIFF
--- a/agent-toolkit/README.MD
+++ b/agent-toolkit/README.MD
@@ -41,8 +41,7 @@ pip install git+https://github.com/tavily-ai/tavily-cookbook.git#subdirectory=ag
 
 ```python
 
-from tavily_agent_toolkit import social_media_search
-from models import ModelConfig, ModelObject
+from tavily_agent_toolkit import social_media_search, ModelConfig, ModelObject
 
 result = await social_media_search(
     query="Who is Leo Messi?",
@@ -74,8 +73,7 @@ You provide a RAG function that queries your internal data. The agent identifies
 4. Synthesize into a comprehensive report
 
 ```python
-from agents.hybrid_researcher import hybrid_research
-from models import ModelConfig, ModelObject
+from agents.hybrid_researcher import hybrid_research, ModelConfig, ModelObject
 
 result = await hybrid_research(
     api_key="tvly-xxx",

--- a/agent-toolkit/README.MD
+++ b/agent-toolkit/README.MD
@@ -73,7 +73,7 @@ You provide a RAG function that queries your internal data. The agent identifies
 4. Synthesize into a comprehensive report
 
 ```python
-from agents.hybrid_researcher import hybrid_research, ModelConfig, ModelObject
+from tavily_agent_toolkit import hybrid_research, ModelConfig, ModelObject
 
 result = await hybrid_research(
     api_key="tvly-xxx",

--- a/agent-toolkit/agents/README.MD
+++ b/agent-toolkit/agents/README.MD
@@ -89,8 +89,7 @@ Best for: Quick answers, lower latency, cost-sensitive applications.
 ```
 
 ```python
-from agents.hybrid_researcher import hybrid_research
-from models import ModelConfig, ModelObject
+from tavily_agent_toolkit import hybrid_research, ModelConfig, ModelObject
 
 # Your RAG function - returns relevant context from your knowledge base
 def my_rag(query: str) -> str:

--- a/agent-toolkit/tools/README.md
+++ b/agent-toolkit/tools/README.md
@@ -21,8 +21,7 @@ Answer a question using web research. Optionally generates subqueries for compre
 **Key parameters:** `query`, `model_config`, `max_number_of_subqueries` (2-4), `output_schema`, `token_limit` (default 50k), `threshold` (default 0.3), `topic` ("general"/"news"/"finance"), `time_range`, `include_domains`, `exclude_domains`
 
 ```python
-from tools.search_and_answer import search_and_answer
-from models import ModelConfig, ModelObject
+from tavily_agent_toolkit import search_and_answer, ModelConfig, ModelObject
 
 result = await search_and_answer(
     query="What are the pros and cons of Rust vs Go?",
@@ -42,7 +41,7 @@ Run multiple search queries in parallel and consolidate results. Deduplicates by
 **Key parameters:** `queries`, `search_depth` ("advanced"), `topic`, `max_results` (5), `chunks_per_source` (3), `time_range`, `include_domains`, `exclude_domains`
 
 ```python
-from tools.async_search_and_dedup import search_dedup
+from tavily_agent_toolkit import async_search_and_dedup
 
 results = await search_dedup(
     api_key="tvly-xxx",
@@ -68,8 +67,7 @@ Crawl an entire website and summarize the content. Bring your own model for the 
 **Key parameters:** `url`, `model_config`, `instructions`, `output_schema`, `max_depth` (1-5), `max_breadth` (20), `limit` (50), `select_paths`, `exclude_paths`
 
 ```python
-from tools.crawl_and_summarize import crawl_and_summarize
-from models import ModelConfig, ModelObject
+from tavily_agent_toolkit import crawl_and_summarize, ModelConfig, ModelObject
 
 result = await crawl_and_summarize(
     url="https://docs.example.com",
@@ -90,8 +88,7 @@ Extract content from specific URLs and summarize with your model. Use when you a
 **Key parameters:** `urls` (max 20), `model_config`, `query` (focuses extraction), `output_schema`, `chunks_per_source` (5), `extract_depth` ("basic"/"advanced")
 
 ```python
-from tools.extract_and_summarize import extract_and_summarize
-from models import ModelConfig, ModelObject
+from tavily_agent_toolkit import extract_and_summarize, ModelConfig, ModelObject
 
 result = await extract_and_summarize(
     urls=["https://en.wikipedia.org/wiki/Artificial_intelligence"],
@@ -111,7 +108,7 @@ Search specific social platforms for discussions and content.
 **Key parameters:** `query`, `platform` ("reddit"/"x"/"linkedin"/"tiktok"/"instagram"/"facebook"/"combined"), `include_raw_content`, `max_results` (5), `time_range`
 
 ```python
-from tools.social_media import social_media_search
+from tavily_agent_toolkit import social_media_search
 
 results = social_media_search(
     query="best practices for LLM fine-tuning",

--- a/agent-toolkit/utilities/README.md
+++ b/agent-toolkit/utilities/README.md
@@ -9,7 +9,7 @@ Helper functions that power the tools and agents. Most are internal, but a few a
 Parse and display streaming responses from Tavily's Research API. Handles SSE events, tool calls, and content chunks.
 
 ```python
-from utilities.research_stream import handle_research_stream
+from tavily_agent_toolkit import handle_research_stream
 
 response = client.research(query="...", stream=True)
 report = handle_research_stream(response, verbose=True)
@@ -22,7 +22,7 @@ report = handle_research_stream(response, verbose=True)
 Remove web noise from raw HTML/markdown content—navigation elements, boilerplate, social buttons, markdown artifacts.
 
 ```python
-from utilities.utils import clean_raw_content
+from tavily_agent_toolkit import clean_raw_content
 
 cleaned = clean_raw_content(raw_webpage_content)
 ```
@@ -34,7 +34,7 @@ cleaned = clean_raw_content(raw_webpage_content)
 Format search results into a structured string optimized for LLM consumption.
 
 ```python
-from utilities.utils import format_web_results
+from tavily_agent_toolkit import format_web_results
 
 formatted = format_web_results(search_results)
 ```
@@ -46,8 +46,7 @@ formatted = format_web_results(search_results)
 **Model cascades are critical for LLM-heavy workflows.** This function handles automatic fallback when models fail—rate limits, outages, or errors trigger the next model in the chain.
 
 ```python
-from utilities.utils import ainvoke_with_fallback
-from models import ModelConfig, ModelObject
+from tavily_agent_toolkit import ainvoke_with_fallback, ModelConfig, ModelObject
 
 config = ModelConfig(
     model=ModelObject(model="gpt-4o"),


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Unifies import patterns across docs** for clearer, package-level usage.
> 
> - Updates examples in `README.MD`, `agents/README.MD`, `tools/README.md`, and `utilities/README.md` to import functions and models directly from `tavily_agent_toolkit` (e.g., `search_and_answer`, `crawl_and_summarize`, `hybrid_research`, `social_media_search`, `handle_research_stream`, `clean_raw_content`, `format_web_results`, `ainvoke_with_fallback`, `ModelConfig`, `ModelObject`).
> - Removes module-relative imports (e.g., `from tools/...`, `from agents/...`, `from utilities...`, `from models ...`) to reflect exported package API.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f744630ca62b1ee52a3e1b4e69212819bf3af51f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->