### PR TITLE
fix: pin minimum versions for vulnerable transitive dependencies

### DIFF
--- a/agent-toolkit/pyproject.toml
+++ b/agent-toolkit/pyproject.toml
@@ -29,6 +29,11 @@ dependencies = [
     "httpx>=0.25.0",
     "langchain>=0.3.0",
     "langchain-openai>=0.2.0",
+    # Security: pinned minimum versions for transitive dependencies
+    "urllib3>=2.6.3",
+    "requests>=2.32.4",
+    "starlette>=0.49.1",
+    "pillow>=11.3.0",
 ]
 
 [project.optional-dependencies]

--- a/agent-toolkit/requirements.txt
+++ b/agent-toolkit/requirements.txt
@@ -12,3 +12,9 @@ langchain-openai>=0.2.0
 pytest>=8.0.0
 pytest-asyncio>=0.24.0
 python-dotenv>=1.0.0
+
+# Security: pinned minimum versions for transitive dependencies
+urllib3>=2.6.3
+requests>=2.32.4
+starlette>=0.49.1
+pillow>=11.3.0

--- a/agent-toolkit/use-cases/claude_sdk/requirements.txt
+++ b/agent-toolkit/use-cases/claude_sdk/requirements.txt
@@ -7,3 +7,7 @@ anthropic>=0.40.0
 
 # Utilities
 python-dotenv>=1.0.0
+
+# Security: pinned minimum versions for transitive dependencies
+urllib3>=2.6.3
+requests>=2.32.4

--- a/agent-toolkit/use-cases/langgraph/requirements.txt
+++ b/agent-toolkit/use-cases/langgraph/requirements.txt
@@ -9,3 +9,7 @@ langchain-openai>=0.2.0
 
 # Utilities
 python-dotenv>=1.0.0
+
+# Security: pinned minimum versions for transitive dependencies
+urllib3>=2.6.3
+requests>=2.32.4

--- a/cookbooks/getting-started/requirements.txt
+++ b/cookbooks/getting-started/requirements.txt
@@ -1,8 +1,14 @@
 tavily-python
-langchain-chroma 
-langchain 
-langchain-tavily 
+langchain-chroma
+langchain
+langchain-tavily
 langgraph
-chromadb 
-pypdf 
+chromadb
+pypdf
 langchain-openai
+
+# Security: pinned minimum versions for transitive dependencies
+urllib3>=2.6.3
+requests>=2.32.4
+starlette>=0.49.1
+pillow>=11.3.0

--- a/cookbooks/integrations/aws-strands/interactive_cli/pyproject.toml
+++ b/cookbooks/integrations/aws-strands/interactive_cli/pyproject.toml
@@ -9,4 +9,8 @@ dependencies = [
     "strands-agents>=0.1.3",
     "strands-agents-tools>=0.1.2",
     "tavily-python>=0.7.17",
+    # Security: pinned minimum versions for transitive dependencies
+    "urllib3>=2.6.3",
+    "requests>=2.32.4",
+    "mcp>=1.23.0",
 ]


### PR DESCRIPTION
## Summary
- Pin minimum versions for vulnerable transitive dependencies across all requirements files
- Addresses 11 open Dependabot security alerts (8 high, 3 medium severity)

## Vulnerabilities Fixed

| Package | Min Version | Severity | Issues |
|---------|-------------|----------|--------|
| `urllib3` | ≥2.6.3 | High | Decompression bomb bypass, streaming API issues |
| `requests` | ≥2.32.4 | Medium | .netrc credentials leak via malicious URLs |
| `starlette` | ≥0.49.1 | High/Medium | O(n²) DoS via Range header, multipart form DoS |
| `pillow` | ≥11.3.0 | High | Write buffer overflow on BCn encoding |
| `mcp` | ≥1.23.0 | High | DNS rebinding, validation error DoS, HTTP transport DoS |

## Files Modified
- `agent-toolkit/requirements.txt`
- `agent-toolkit/pyproject.toml`
- `agent-toolkit/use-cases/langgraph/requirements.txt`
- `agent-toolkit/use-cases/claude_sdk/requirements.txt`
- `cookbooks/getting-started/requirements.txt`
- `cookbooks/integrations/aws-strands/interactive_cli/pyproject.toml`

## Test Plan
- [ ] Verify dependencies install correctly with `pip install -r requirements.txt`
- [ ] Confirm Dependabot alerts are resolved after merge